### PR TITLE
Fixes line endings on linux

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "preserveConstEnums": true,
     "removeComments": true,
     "target": "es6",
-    "sourceMap": true
+    "sourceMap": true,
+    "newLine": "LF"
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
This module errors out on linux with : No such file or directory as it has CRLF line endings for main.js.
Based on #29
Closes #18, #29, #36