### PR TITLE
small watch improvements and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ before_install:
   - docker build -t funcpack-test-suite .
 
 script:
-  - docker run -e "DEBUG=azure-functions-pack:*" funcpack-test-suite:latest
+  - docker run -e "DEBUG=azure-functions-pack:*" -e "DEBUG_FD=1" funcpack-test-suite:latest

--- a/src/webpack-runner.ts
+++ b/src/webpack-runner.ts
@@ -83,11 +83,12 @@ export class WebpackRunner {
             debug("Started webpack");
 
             if (options.watch) {
-                compiler.watch(null, async (err, stats) => {
+                compiler.watch(null, (err, stats) => {
                     debug("Webpack recompile");
                     if (err || stats.hasErrors()) {
                         return reject(err || stats.toString({ errors: true }));
                     }
+                    winston.info("Webpack compiled successfully. Watching for changes.");
                     debug("\n" + stats.toString());
                 });
             } else {

--- a/test/e2e/e2e.test.ts
+++ b/test/e2e/e2e.test.ts
@@ -253,6 +253,154 @@ describe("e2e tests", function() {
                     .expect(200, done);
             });
         });
+    });
+
+    describe("funcpack pack -w . ", function() {
+        const randomNumber = Math.floor(Math.random() * 10000);
+        const testRoot = path.resolve(os.tmpdir(), `./AzureFunctionsPackTest${randomNumber}`);
+        log(`Using temp dir: ${testRoot}`);
+        describe("cli", function() {
+            before(async function() {
+                this.timeout(60000);
+                return await FileHelper.cp(sampleRoot, testRoot);
+            });
+
+            after(async function() {
+                this.timeout(60000);
+                if (process.env.FUNCPACK_TESTS_CLEAN) {
+                    return await FileHelper.rimraf(testRoot);
+                } else {
+                    return Promise.resolve();
+                }
+            });
+
+            it("should run successfully", async function() {
+                this.timeout(60000);
+                try {
+                    const childProcess = spawn("node",
+                        [path.resolve(__dirname, "../../lib/main.js"), "pack", "-w", "."], { cwd: testRoot });
+
+                    const waitForWatch = await new Promise<boolean>((resolve, reject) => {
+                        childProcess.stdout.on("data", (data: string) => {
+                            if (data.toString().includes ("Webpack compiled successfully. Watching for changes.")) {
+                                resolve(true);
+                                childProcess.kill();
+                            }
+                        });
+
+                        childProcess.stderr.on("data", (data: string) => {
+                            reject(data.toString());
+                            childProcess.kill();
+                        });
+                    });
+
+                    return Promise.resolve();
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+            });
+        });
+
+        describe("host", function() {
+            let host: FunctionHostHarness;
+
+            before(async function() {
+                this.timeout(90000);
+                await ProcessHelper.killAllFunctionsHosts();
+                if (!await FileHelper.exists(testRoot)) {
+                    await FileHelper.cp(sampleRoot, testRoot);
+                }
+                const childProcess = spawn("node",
+                [path.resolve(__dirname, "../../lib/main.js"), "pack", "-w", "."], { cwd: testRoot });
+
+                const waitForWatch = await new Promise<boolean>((resolve, reject) => {
+                    childProcess.stdout.on("data", (data: string) => {
+                        if (data.toString().includes ("Webpack compiled successfully. Watching for changes.")) {
+                            resolve(true);
+                            childProcess.kill();
+                        }
+                    });
+
+                    childProcess.stderr.on("data", (data: string) => {
+                        reject(data.toString());
+                        childProcess.kill();
+                    });
+                });
+
+                host = new FunctionHostHarness(testRoot);
+                await host.init();
+                return new Promise((resolve, reject) => {
+                    const int = setInterval(() => {
+                        host.test("simple")
+                            .then((res: any) => {
+                                log(JSON.stringify(res));
+                                if (res.status === 200) {
+                                    clearTimeout(int);
+                                    resolve();
+                                }
+                            }).catch((e) => log(e));
+                    }, 500);
+                });
+            });
+
+            after(async function() {
+                this.timeout(60000);
+                host.stop();
+                await ProcessHelper.killAllFunctionsHosts();
+                if (process.env.FUNCPACK_TESTS_CLEAN) {
+                    return await FileHelper.rimraf(testRoot);
+                } else {
+                    return Promise.resolve();
+                }
+            });
+
+            it("should ignore non-js files", function(done) {
+                const funcname = process.env.FUNCPACK_TESTS_V2 ? "cs-ignoreme-v2" : "cs-ignoreme";
+                host.test(funcname)
+                    .expect(200, done);
+            });
+
+            it("should obey entryPoint setting", function(done) {
+                host.test("entryPoint")
+                    .expect(200, done);
+            });
+
+            it("should obey excluded setting", function(done) {
+                host.test("excluded")
+                    .expect(200, done);
+            });
+
+            it("should work with external script files", function(done) {
+                host.test("externalScriptFile")
+                    .expect(200, done);
+            });
+
+            it("should work with large imports", function(done) {
+                host.test("largeimport")
+                    .expect(200, done);
+            });
+
+            it("should work with local libs", function(done) {
+                host.test("libimport")
+                    .expect(200, done);
+            });
+
+            it("should obey scriptFile setting", function(done) {
+                host.test("scriptFile")
+                    .expect(200, done);
+            });
+
+            it("should work with simple functions", function(done) {
+                host.test("simple")
+                    .expect(200, done);
+            });
+
+            it("should work with simple imports", function(done) {
+                host.test("simpleimport")
+                    .expect(200, done);
+            });
+        });
 
     });
+
 });


### PR DESCRIPTION
- Adding basic unit tests for watch mode
- Forward date the packhost modified time stamp 10 seconds to keep the watcher from going crazy, see: https://github.com/webpack/watchpack/issues/25
- Improved the watch mode logging to make it easier see rebuilds occuring
